### PR TITLE
Support custom payload hasher for computing unique key.

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1066,7 +1066,7 @@ func TestClientEnqueueUnique(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		gotTTL := r.TTL(context.Background(), base.UniqueKey(base.DefaultQueueName, tc.task.Type(), tc.task.Payload())).Val()
+		gotTTL := r.TTL(context.Background(), base.UniqueKey(base.DefaultQueueName, tc.task.Type(), tc.task.Payload(), nil)).Val()
 		if !cmp.Equal(tc.ttl.Seconds(), gotTTL.Seconds(), cmpopts.EquateApprox(0, 1)) {
 			t.Errorf("TTL = %v, want %v", gotTTL, tc.ttl)
 			continue
@@ -1111,7 +1111,7 @@ func TestClientEnqueueUniqueWithProcessInOption(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		gotTTL := r.TTL(context.Background(), base.UniqueKey(base.DefaultQueueName, tc.task.Type(), tc.task.Payload())).Val()
+		gotTTL := r.TTL(context.Background(), base.UniqueKey(base.DefaultQueueName, tc.task.Type(), tc.task.Payload(), nil)).Val()
 		wantTTL := time.Duration(tc.ttl.Seconds()+tc.d.Seconds()) * time.Second
 		if !cmp.Equal(wantTTL.Seconds(), gotTTL.Seconds(), cmpopts.EquateApprox(0, 1)) {
 			t.Errorf("TTL = %v, want %v", gotTTL, wantTTL)
@@ -1157,7 +1157,7 @@ func TestClientEnqueueUniqueWithProcessAtOption(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		gotTTL := r.TTL(context.Background(), base.UniqueKey(base.DefaultQueueName, tc.task.Type(), tc.task.Payload())).Val()
+		gotTTL := r.TTL(context.Background(), base.UniqueKey(base.DefaultQueueName, tc.task.Type(), tc.task.Payload(), nil)).Val()
 		wantTTL := tc.at.Add(tc.ttl).Sub(time.Now())
 		if !cmp.Equal(wantTTL.Seconds(), gotTTL.Seconds(), cmpopts.EquateApprox(0, 1)) {
 			t.Errorf("TTL = %v, want %v", gotTTL, wantTTL)

--- a/internal/rdb/benchmark_test.go
+++ b/internal/rdb/benchmark_test.go
@@ -38,7 +38,7 @@ func BenchmarkEnqueueUnique(b *testing.B) {
 		Type:      "task1",
 		Payload:   nil,
 		Queue:     base.DefaultQueueName,
-		UniqueKey: base.UniqueKey("default", "task1", nil),
+		UniqueKey: base.UniqueKey("default", "task1", nil, nil),
 	}
 	uniqueTTL := 5 * time.Minute
 	b.ResetTimer()
@@ -79,7 +79,7 @@ func BenchmarkScheduleUnique(b *testing.B) {
 		Type:      "task1",
 		Payload:   nil,
 		Queue:     base.DefaultQueueName,
-		UniqueKey: base.UniqueKey("default", "task1", nil),
+		UniqueKey: base.UniqueKey("default", "task1", nil, nil),
 	}
 	processAt := time.Now().Add(3 * time.Minute)
 	uniqueTTL := 5 * time.Minute

--- a/internal/rdb/inspect_test.go
+++ b/internal/rdb/inspect_test.go
@@ -4283,7 +4283,7 @@ func TestDeleteTaskWithUniqueLock(t *testing.T) {
 		Type:      "email",
 		Payload:   h.JSON(map[string]interface{}{"user_id": json.Number("123")}),
 		Queue:     base.DefaultQueueName,
-		UniqueKey: base.UniqueKey(base.DefaultQueueName, "email", h.JSON(map[string]interface{}{"user_id": 123})),
+		UniqueKey: base.UniqueKey(base.DefaultQueueName, "email", h.JSON(map[string]interface{}{"user_id": 123}), nil),
 	}
 	t1 := time.Now().Add(3 * time.Hour)
 

--- a/internal/rdb/rdb.go
+++ b/internal/rdb/rdb.go
@@ -598,7 +598,7 @@ func (r *RDB) AddToGroupUnique(ctx context.Context, msg *base.TaskMessage, group
 		base.TaskKey(msg.Queue, msg.ID),
 		base.GroupKey(msg.Queue, groupKey),
 		base.AllGroups(msg.Queue),
-		base.UniqueKey(msg.Queue, msg.Type, msg.Payload),
+		msg.UniqueKey, // Already available in TaskMessage (no need to recompute this).
 	}
 	argv := []interface{}{
 		encoded,

--- a/internal/rdb/rdb_test.go
+++ b/internal/rdb/rdb_test.go
@@ -168,7 +168,7 @@ func TestEnqueueUnique(t *testing.T) {
 		Type:      "email",
 		Payload:   h.JSON(map[string]interface{}{"user_id": json.Number("123")}),
 		Queue:     base.DefaultQueueName,
-		UniqueKey: base.UniqueKey(base.DefaultQueueName, "email", h.JSON(map[string]interface{}{"user_id": 123})),
+		UniqueKey: base.UniqueKey(base.DefaultQueueName, "email", h.JSON(map[string]interface{}{"user_id": 123}), nil),
 	}
 
 	enqueueTime := time.Now()
@@ -1234,7 +1234,7 @@ func TestAddToGroup(t *testing.T) {
 	}
 }
 
-func TestAddToGroupeTaskIdConflictError(t *testing.T) {
+func TestAddToGroupTaskIdConflictError(t *testing.T) {
 	r := setup(t)
 	defer r.Close()
 
@@ -1282,7 +1282,7 @@ func TestAddToGroupUnique(t *testing.T) {
 	now := time.Now()
 	r.SetClock(timeutil.NewSimulatedClock(now))
 	msg := h.NewTaskMessage("mytask", []byte("foo"))
-	msg.UniqueKey = base.UniqueKey(msg.Queue, msg.Type, msg.Payload)
+	msg.UniqueKey = base.UniqueKey(msg.Queue, msg.Type, msg.Payload, nil)
 	ctx := context.Background()
 
 	tests := []struct {
@@ -1506,7 +1506,7 @@ func TestScheduleUnique(t *testing.T) {
 		Type:      "email",
 		Payload:   h.JSON(map[string]interface{}{"user_id": 123}),
 		Queue:     base.DefaultQueueName,
-		UniqueKey: base.UniqueKey(base.DefaultQueueName, "email", h.JSON(map[string]interface{}{"user_id": 123})),
+		UniqueKey: base.UniqueKey(base.DefaultQueueName, "email", h.JSON(map[string]interface{}{"user_id": 123}), nil),
 	}
 
 	tests := []struct {


### PR DESCRIPTION
Support custom payload hasher to compute unique key. Used in cases where equivalent payloads are not deterministically serialized to bytes. JSON maps are a good example of this. 