### PR TITLE
Fix issue when parsing redis url with trailing slash

### DIFF
--- a/asynq.go
+++ b/asynq.go
@@ -467,9 +467,11 @@ func parseRedisURI(u *url.URL) (RedisConnOpt, error) {
 
 	if len(u.Path) > 0 {
 		xs := strings.Split(strings.Trim(u.Path, "/"), "/")
-		db, err = strconv.Atoi(xs[0])
-		if err != nil {
-			return nil, fmt.Errorf("asynq: could not parse redis uri: database number should be the first segment of the path")
+		if len(xs[0]) > 0 {
+			db, err = strconv.Atoi(xs[0])
+			if err != nil {
+				return nil, fmt.Errorf("asynq: could not parse redis uri: database number should be the first segment of the path")
+			}
 		}
 	}
 	var password string

--- a/asynq_test.go
+++ b/asynq_test.go
@@ -102,7 +102,15 @@ func TestParseRedisURI(t *testing.T) {
 			RedisClientOpt{Addr: "localhost:6379"},
 		},
 		{
+			"redis://localhost:6379/",
+			RedisClientOpt{Addr: "localhost:6379"},
+		},
+		{
 			"rediss://localhost:6379",
+			RedisClientOpt{Addr: "localhost:6379", TLSConfig: &tls.Config{ServerName: "localhost"}},
+		},
+		{
+			"rediss://localhost:6379/",
 			RedisClientOpt{Addr: "localhost:6379", TLSConfig: &tls.Config{ServerName: "localhost"}},
 		},
 		{


### PR DESCRIPTION
Fix issue when parsing redis url with trailing slash.

For example, `redis://localhost:6370/` would not be parsed correctly. It would result in an error complaining about missing db number. This is a valid URL that is accepted by other redis clients in other languages. Asynq should handle this real-world case of extraneous trailing slash.